### PR TITLE
Remove dependency on glium_macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ git = "https://github.com/PistonDevelopers/freetype-rs"
 [dependencies.piston2d-graphics]
 git = "https://github.com/PistonDevelopers/graphics"
 
-[dependencies.glium_macros]
-git = "https://github.com/tomaka/glium"
-
 [dependencies.glium]
 git = "https://github.com/tomaka/glium"
 features = ["image", "gl_read_buffer"]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 use std::default::Default;
 use graphics::{self, ImageSize, BackEnd};
 use glium::{Display, Surface, Texture2d, Texture, Program, VertexBuffer,
-            DrawParameters, BlendingFunction, LinearBlendingFactor};
+            DrawParameters, BlendingFunction, LinearBlendingFactor, Vertex};
 use glium::index::{NoIndices, PrimitiveType};
+use glium::vertex::{VertexFormat, AttributeType};
 use shader;
 
 
@@ -26,18 +27,33 @@ impl ImageSize for DrawTexture {
 }
 
 
-#[vertex_format]
 #[derive(Copy, Clone)]
 struct PlainVertex {
     position: [f32; 2],
 }
 
+impl Vertex for PlainVertex {
+    fn build_bindings() -> VertexFormat {
+        vec![
+            ("position".to_string(), 0, AttributeType::F32F32),
+        ]
+    }
+}
 
-#[vertex_format]
+
 #[derive(Copy, Clone)]
 struct TexturedVertex {
     position: [f32; 2],
     texcoord: [f32; 2],
+}
+
+impl Vertex for TexturedVertex {
+    fn build_bindings() -> VertexFormat {
+        vec![
+            ("position".to_string(), 0, AttributeType::F32F32),
+            ("texcoord".to_string(), 8, AttributeType::F32F32),
+        ]
+    }
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(plugin)]
-#![plugin(glium_macros)]
-
 extern crate freetype;
 #[macro_use(uniform)]
 extern crate glium;


### PR DESCRIPTION
Syntax extensions will not be available for 1.0. Therefore the simple Vertex implementations in this crate can be done manually instead.