### PR TITLE
Prepare for publishing to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,20 +7,24 @@ authors = [
 ]
 
 [dependencies]
-image = "*"
+image = "0.3"
 
 [dev-dependencies]
-glutin = "*"
+glutin = "0.0.22"
 
 [dependencies.freetype-rs]
 git = "https://github.com/PistonDevelopers/freetype-rs"
+#version = "0.0.8"
 
 [dependencies.piston2d-graphics]
 git = "https://github.com/PistonDevelopers/graphics"
+#version = "0.0.27"
 
 [dependencies.shader_version]
 git = "https://github.com/PistonDevelopers/shader_version"
+#version = "0.0.6"
 
 [dependencies.glium]
+version = "0.2"
 features = ["image", "gl_read_buffer"]
 default_features = false


### PR DESCRIPTION
Added concrete version numbers (commented out for those dependencies, which should track the respective git repository).

Not sure, whether it might be sensible to add the exact dependency for `glium` and `image`. @tomaka, do you intend to keep the releases backwards-compatible within a `0.x` version?