### PR TITLE
Fix creation of Glium window

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -15,7 +15,7 @@ pub struct GliumWindow(Rc<Context>);
 
 impl GliumWindow {
     /// Creates new GliumWindow.
-    pub fn new<W>(window: &Rc<RefCell<W>>) -> Result<Self, GliumCreationError>
+    pub fn new<W>(window: &Rc<RefCell<W>>) -> Result<Self, GliumCreationError<()>>
         where W: OpenGLWindow + 'static
     {
         unsafe {


### PR DESCRIPTION
Glium's context creation is now generic over the error type. As we are not really throwing our own errors, it is reasonable to just use `()` here.