### PR TITLE
Move to crates.io dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,24 +18,24 @@ name = "glium_graphics"
 image = "0.3"
 
 [dependencies.freetype-rs]
-git = "https://github.com/PistonDevelopers/freetype-rs"
-#version = "0.0.9"
+#git = "https://github.com/PistonDevelopers/freetype-rs"
+version = "0.0.9"
 
 [dependencies.piston2d-graphics]
-git = "https://github.com/PistonDevelopers/graphics"
-#version = "0.0.45"
+#git = "https://github.com/PistonDevelopers/graphics"
+version = "0.0.47"
 
 [dependencies.shader_version]
-git = "https://github.com/PistonDevelopers/shader_version"
-#version = "0.0.6"
+#git = "https://github.com/PistonDevelopers/shader_version"
+version = "0.0.6"
 
 [dependencies.piston-shaders_graphics2d]
-git = "https://github.com/PistonDevelopers/shaders"
-#version = "0.0.0"
+#git = "https://github.com/PistonDevelopers/shaders"
+version = "0.0.0"
 
 [dependencies.pistoncore-window]
-git = "https://github.com/PistonDevelopers/window"
-#version = "0.1.1"
+#git = "https://github.com/PistonDevelopers/window"
+version = "0.1.1"
 
 [dependencies.glium]
 version = "0.3"
@@ -43,10 +43,9 @@ features = ["image"]
 default_features = false
 
 [dev-dependencies.piston]
-git = "https://github.com/PistonDevelopers/piston"
-#version = "0.1.1"
+#git = "https://github.com/PistonDevelopers/piston"
+version = "0.1.1"
 
-[dev-dependencies.pistoncore-sdl2_window]
-git = "https://github.com/PistonDevelopers/sdl2_window"
-#version = "0.0.12"
-
+[dev-dependencies.pistoncore-glutin_window]
+#git = "https://github.com/PistonDevelopers/glutin_window"
+version = "0.0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ version = "0.0.0"
 version = "0.1.1"
 
 [dependencies.glium]
-version = "0.3"
+version = "0.4"
 features = ["image"]
 default_features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piston2d-glium_graphics"
-version = "0.0.13"
+version = "0.0.14"
 authors = [
     "Eduard Bopp <eduard.bopp@aepsil0n.de>",
     "bvssvni <bvssvni@gmail.com>"

--- a/examples/image_test.rs
+++ b/examples/image_test.rs
@@ -3,7 +3,7 @@ extern crate glium;
 extern crate glium_graphics;
 extern crate image;
 extern crate piston;
-extern crate sdl2_window;
+extern crate glutin_window;
 
 use std::rc::Rc;
 use std::cell::RefCell;
@@ -12,13 +12,13 @@ use glium::{ Surface, Texture2d };
 use glium_graphics::{ Glium2d, GliumGraphics, DrawTexture, GliumWindow };
 use piston::event::*;
 use piston::window::{ WindowSettings, Size };
-use sdl2_window::{ Sdl2Window, OpenGL };
+use glutin_window::{ GlutinWindow, OpenGL };
 
 fn main() {
     let opengl = OpenGL::_3_2;
     let (w, h) = (300, 300);
     let ref window = Rc::new(RefCell::new(
-        Sdl2Window::new(
+        GlutinWindow::new(
             opengl,
             WindowSettings::new(
                 "glium_graphics: image_test".to_string(),

--- a/examples/text_test.rs
+++ b/examples/text_test.rs
@@ -1,6 +1,6 @@
 extern crate piston;
 extern crate graphics;
-extern crate sdl2_window;
+extern crate glutin_window;
 extern crate glium_graphics;
 
 use std::cell::RefCell;
@@ -9,13 +9,13 @@ use std::path::Path;
 use piston::window::{ WindowSettings, Size };
 use piston::event::*;
 use glium_graphics::{ GliumGraphics, Glium2d, GliumWindow, GlyphCache };
-use sdl2_window::{ Sdl2Window, OpenGL };
+use glutin_window::{ GlutinWindow, OpenGL };
 
 fn main() {
     let opengl = OpenGL::_3_2;
     let size = Size { width: 500, height: 300 };
     let ref window = Rc::new(RefCell::new(
-        Sdl2Window::new(
+        GlutinWindow::new(
             opengl,
             WindowSettings::new("gfx_graphics: text_test", size)
                 .exit_on_esc(true)


### PR DESCRIPTION
This updates a couple of dependencies.

Also the windowing backend is changed from SDL2 to Glutin, as the SDL2 backend is not yet crates.io-ready.