### PR TITLE
Partially fixed Retina display error

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -110,7 +110,7 @@ unsafe impl<W> Backend for Wrapper<W> where W: OpenGLWindow {
     }
 
     fn get_framebuffer_dimensions(&self) -> (u32, u32) {
-        let size = self.0.borrow().size();
+        let size = self.0.borrow().draw_size();
         (size.width, size.height)
     }
 


### PR DESCRIPTION
On a retina screen:
<img width="612" alt="capture d ecran 2016-07-04 a 14 34 35" src="https://cloud.githubusercontent.com/assets/3610253/16560609/ce0eb662-41f4-11e6-8f8c-56ec8cdd0908.png">

Regular screen:
![capture d ecran 2016-07-04 a 14 34 29](https://cloud.githubusercontent.com/assets/3610253/16560610/cfc59df4-41f4-11e6-882f-1658e741e8e7.png)

Now It's fixed (here is Retina):
<img width="612" alt="capture d ecran 2016-07-04 a 14 50 12" src="https://cloud.githubusercontent.com/assets/3610253/16560937/a4f1f076-41f6-11e6-9c15-aefae34ba2e3.png">

But when I move the window from the retina to the regular (or the other way),
From regular to Retina:
<img width="612" alt="capture d ecran 2016-07-04 a 14 52 02" src="https://cloud.githubusercontent.com/assets/3610253/16560981/fc2799a4-41f6-11e6-93e4-6de815ed6cb4.png">

From Retina to regular:
![capture d ecran 2016-07-04 a 14 52 17](https://cloud.githubusercontent.com/assets/3610253/16560985/05837ff4-41f7-11e6-9916-39b1ecea456c.png)
