### PR TITLE
Fix bug causing text to be drawn 2 pixels off

### DIFF
--- a/src/glyph_cache.rs
+++ b/src/glyph_cache.rs
@@ -113,7 +113,7 @@ impl<F: Facade> CharacterCache for GlyphCache<F> {
 
                 let &mut (offset, size, ref texture) = v.insert((
                     [
-                        bounding_box.min.x as Scalar + 1.0,
+                        bounding_box.min.x as Scalar - 1.0,
                         -pixel_bounding_box.min.y as Scalar + 1.0,
                     ],
                     [


### PR DESCRIPTION
It appears that c9e53ec4ac17c91fd208890b132c81ab323af1ff introduced a bug causing text to be drawn 2 pixels to the right of where it should be.