### PR TITLE
Added TextureSettings to GlyphCache

### DIFF
--- a/examples/text_test.rs
+++ b/examples/text_test.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use piston::window::{ WindowSettings, Size };
 use piston::input::RenderEvent;
 use piston::event_loop::EventLoop;
-use glium_graphics::{ Glium2d, GliumWindow, GlyphCache, OpenGL };
+use glium_graphics::{ Glium2d, GliumWindow, GlyphCache, OpenGL, TextureSettings };
 
 fn main() {
     let opengl = OpenGL::V3_2;
@@ -17,7 +17,8 @@ fn main() {
 
     let mut glyph_cache = GlyphCache::new(
         Path::new("assets/FiraSans-Regular.ttf"),
-        window.clone()
+        window.clone(),
+        TextureSettings::new()
     ).unwrap();
 
     let mut g2d = Glium2d::new(opengl, window);

--- a/src/glyph_cache.rs
+++ b/src/glyph_cache.rs
@@ -29,21 +29,23 @@ impl From<io::Error> for Error {
 pub struct GlyphCache<F> {
     font: Font<'static>,
     data: HashMap<(FontSize, char), ([Scalar; 2], [Scalar; 2], Texture)>,
+    settings: TextureSettings,
     facade: F,
 }
 
 impl<F> GlyphCache<F> where F: Facade {
     /// Constructs a GlyphCache from a Font.
-    pub fn from_font(font: Font<'static>, facade: F) -> Self {
+    pub fn from_font(font: Font<'static>, facade: F, settings: TextureSettings) -> Self {
         GlyphCache {
             font: font,
             data: HashMap::new(),
+            settings: settings,
             facade: facade,
         }
     }
 
      /// Constructor for a GlyphCache.
-    pub fn new<P>(font_path: P, facade: F) -> Result<Self, Error>
+    pub fn new<P>(font_path: P, facade: F, settings: TextureSettings) -> Result<Self, Error>
         where P: AsRef<Path>
     {
         use std::io::Read;
@@ -59,7 +61,7 @@ impl<F> GlyphCache<F> where F: Facade {
             None => return Err(Error::NoFont),
         };
 
-        Ok(Self::from_font(font, facade))
+        Ok(Self::from_font(font, facade, settings))
     }
 }
 
@@ -135,7 +137,7 @@ impl<F: Facade> CharacterCache for GlyphCache<F> {
                                 &image_buffer,
                                 pixel_bb_width as u32,
                                 pixel_bb_height as u32,
-                                &TextureSettings::new()
+                                &self.settings
                             ).unwrap()
                         }
                     },


### PR DESCRIPTION
This brings `glium_graphics` up to parity with https://github.com/PistonDevelopers/opengl_graphics/pull/277 and https://github.com/PistonDevelopers/gfx_graphics/pull/331. 