### PR TITLE
Make glutin_window and piston optional under the on by default glium_window feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ documentation = "https://docs.rs/piston2d-glium_graphics"
 [lib]
 name = "glium_graphics"
 
+[features]
+default = ["glium_window"]
+glium_window = ["piston", "pistoncore-glutin_window"]
 
 [dependencies.glium]
 version = "0.20.0"
@@ -24,9 +27,9 @@ default_features = false
 image = "0.18.0"
 piston-shaders_graphics2d = "0.3.1"
 piston-texture = "0.6.0"
-piston = "0.35.0"
+piston = { version = "0.35.0", optional = true }
 shader_version = "0.3.0"
-pistoncore-glutin_window = "0.44.0"
+pistoncore-glutin_window = { version = "0.44.0", optional = true }
 
 [dependencies.piston2d-graphics]
 version = "0.25.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate texture;
 
 pub use shader_version::OpenGL;
 
+#[cfg(feature = "glium_window")]
 pub use window::GliumWindow;
 
 /// Stores textures for text rendering.
@@ -22,6 +23,7 @@ pub use texture::*;
 pub use glium_texture::{ Flip, Texture };
 
 mod back_end;
+#[cfg(feature = "glium_window")]
 mod window;
 mod draw_state;
 mod glium_texture;


### PR DESCRIPTION
Examples won't build without this feature enabled. It seems cleaner to keep it that way rather than add lots of cfgs.

Should this feature be documented and where?

Closes #156